### PR TITLE
Report messages through VkDebugUtilsMessengerEXT

### DIFF
--- a/src/WitchDoc.cpp
+++ b/src/WitchDoc.cpp
@@ -30,17 +30,21 @@ void WitchDoctor::PerformanceWarningMessage(std::string& message) {
     VkDebugUtilsMessengerCallbackDataEXT callback_data = {};
     callback_data.sType =
         VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT;
-    callback_data.pMessage =
-        message.c_str();
+    callback_data.pMessage = message.c_str();
 
     for (const auto& messenger : m_debug_utils_messengers) {
       messenger.second.pfnUserCallback(
           VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT,
-          VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT, &callback_data, messenger.second.pUserData);
+          VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT, &callback_data,
+          messenger.second.pUserData);
     }
   } else {
-      // TODO: Support visual studio outputdebug
+#if defined(WIN32)
+    OutputDebugString(message.c_str());
+    OutputDebugString("\n");
+#else   // defined(WIN32)
     std::cout << message.c_str() << std::endl;
+#endif  // defined(WIN32)
   }
 }
 

--- a/src/WitchDoc.cpp
+++ b/src/WitchDoc.cpp
@@ -16,10 +16,32 @@
 
 #include "WitchDoc.h"
 
+#include <iostream>
+
 namespace GWD {
 
 WitchDoctor::WitchDoctor() {}
 
 WitchDoctor::~WitchDoctor() {}
 
-} // namespace GWD
+void WitchDoctor::PerformanceWarningMessage(std::string& message) {
+  if (m_debug_utils_messengers.size() > 0) {
+    std::lock_guard<std::mutex> lock(m_debug_utils_messenger_mutex);
+    VkDebugUtilsMessengerCallbackDataEXT callback_data = {};
+    callback_data.sType =
+        VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT;
+    callback_data.pMessage =
+        message.c_str();
+
+    for (const auto& messenger : m_debug_utils_messengers) {
+      messenger.second.pfnUserCallback(
+          VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT,
+          VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT, &callback_data, messenger.second.pUserData);
+    }
+  } else {
+      // TODO: Support visual studio outputdebug
+    std::cout << message.c_str() << std::endl;
+  }
+}
+
+}  // namespace GWD

--- a/src/WitchDoc.h
+++ b/src/WitchDoc.h
@@ -99,6 +99,8 @@ class WitchDoctor {
   void PopulateInstanceLayerBypassDispatchTable();
   void PopulateDeviceLayerBypassDispatchTable();
 
+  void PerformanceWarningMessage(std::string& message);
+
  private:
   LayerBypassDispatch m_layerBypassDispatch = {};
 

--- a/src/WitchDoc.h
+++ b/src/WitchDoc.h
@@ -21,6 +21,7 @@
 #include <vulkan/vulkan.h>
 
 #include "flat_hash_map.hpp"
+#include <mutex>
 #include <vector>
 
 namespace GWD {
@@ -39,6 +40,14 @@ class WitchDoctor {
   VkResult PostCallCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
                                   const VkAllocationCallbacks* pAllocator,
                                   VkInstance* pInstance);
+  VkResult PostCallCreateDebugUtilsMessengerEXT(
+      const VkResult inResult, VkInstance instance,
+      VkDebugUtilsMessengerCreateInfoEXT const* pCreateInfo,
+      const VkAllocationCallbacks* pAllocator,
+      VkDebugUtilsMessengerEXT* pMessenger);
+  void PostCallDestroyDebugUtilsMessengerEXT(
+      VkInstance instance, VkDebugUtilsMessengerEXT messenger,
+      const VkAllocationCallbacks* pAllocator);
   VkResult PostCallCreateDevice(VkPhysicalDevice physicalDevice,
                                 const VkDeviceCreateInfo* pCreateInfo,
                                 const VkAllocationCallbacks* pAllocator,
@@ -95,6 +104,11 @@ class WitchDoctor {
 
   VkInstance m_instance = VK_NULL_HANDLE;
   VkDevice m_device = VK_NULL_HANDLE;
+
+  std::mutex m_debug_utils_messenger_mutex;
+  ska::flat_hash_map<VkDebugUtilsMessengerEXT,
+                            VkDebugUtilsMessengerCreateInfoEXT>
+      m_debug_utils_messengers;
 
   VkPhysicalDeviceMemoryProperties m_physDevMemProps = {};
   std::vector<bool> m_memTypeIsDeviceLocal;

--- a/src/WitchDoc.h
+++ b/src/WitchDoc.h
@@ -20,9 +20,10 @@
 
 #include <vulkan/vulkan.h>
 
-#include "flat_hash_map.hpp"
+#include <sstream>
 #include <mutex>
 #include <vector>
+#include "flat_hash_map.hpp"
 
 namespace GWD {
 
@@ -101,6 +102,24 @@ class WitchDoctor {
 
   void PerformanceWarningMessage(std::string& message);
 
+  class MessageLogger {
+   public:
+    MessageLogger(WitchDoctor* instance) : m_instance(instance) {}
+
+    ~MessageLogger() {
+      m_stream.flush();
+      // callback_(stream_.str());
+      m_instance->PerformanceWarningMessage(m_stream.str());
+    }
+
+    std::ostream& stream() { return m_stream; }
+
+   private:
+    // std::function<void(const std::string& msg)> callback_;
+    WitchDoctor* m_instance;
+    std::stringstream m_stream;
+  };
+
  private:
   LayerBypassDispatch m_layerBypassDispatch = {};
 
@@ -109,7 +128,7 @@ class WitchDoctor {
 
   std::mutex m_debug_utils_messenger_mutex;
   ska::flat_hash_map<VkDebugUtilsMessengerEXT,
-                            VkDebugUtilsMessengerCreateInfoEXT>
+                     VkDebugUtilsMessengerCreateInfoEXT>
       m_debug_utils_messengers;
 
   VkPhysicalDeviceMemoryProperties m_physDevMemProps = {};

--- a/src/apiLogic.cpp
+++ b/src/apiLogic.cpp
@@ -22,6 +22,8 @@
 
 namespace GWD {
 
+#define LOG_MESSAGE MessageLogger(this).stream()
+
 PFN_vkVoidFunction WitchDoctor::GetDeviceProcAddr_DispatchHelper(
     const char* pName) {
   return GWDInterface::GwdGetDispatchedDeviceProcAddr(m_device, pName);
@@ -188,10 +190,13 @@ void WitchDoctor::PostCallCmdDrawIndexed(
     //std::cout
     //    << "vkCmdDrawIndexed is using index buffer that is not DEVICE_LOCAL"
     //    << std::endl;
-    std::ostringstream warn_log;
-    warn_log
+    //std::ostringstream warn_log;
+    //warn_log
+    //    << "vkCmdDrawIndexed is using index buffer that is not DEVICE_LOCAL";
+    //PerformanceWarningMessage(warn_log.str());
+
+    LOG_MESSAGE
         << "vkCmdDrawIndexed is using index buffer that is not DEVICE_LOCAL";
-    PerformanceWarningMessage(warn_log.str());
   }
 
   if (!m_vertex_buffers_are_device_local) {

--- a/src/apiLogic.cpp
+++ b/src/apiLogic.cpp
@@ -174,12 +174,8 @@ void WitchDoctor::PostCallCmdDraw(VkCommandBuffer commandBuffer,
                                   uint32_t firstVertex,
                                   uint32_t firstInstance) {
   if (!m_vertex_buffers_are_device_local) {
-    //std::cout << "vkCmdDraw is using vertex buffers that are not DEVICE_LOCAL"
-    //          << std::endl;
-
-    std::ostringstream warn_log;
-    warn_log << "vkCmdDraw is using vertex buffers that are not DEVICE_LOCAL";
-    PerformanceWarningMessage(warn_log.str());
+    LOG_MESSAGE
+        << "vkCmdDraw is using vertex buffers that are not DEVICE_LOCAL";
   }
 }
 
@@ -187,21 +183,13 @@ void WitchDoctor::PostCallCmdDrawIndexed(
     VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
     uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance) {
   if (!m_index_buffer_is_device_local) {
-    //std::cout
-    //    << "vkCmdDrawIndexed is using index buffer that is not DEVICE_LOCAL"
-    //    << std::endl;
-    //std::ostringstream warn_log;
-    //warn_log
-    //    << "vkCmdDrawIndexed is using index buffer that is not DEVICE_LOCAL";
-    //PerformanceWarningMessage(warn_log.str());
-
     LOG_MESSAGE
         << "vkCmdDrawIndexed is using index buffer that is not DEVICE_LOCAL";
   }
 
   if (!m_vertex_buffers_are_device_local) {
-    std::cout << "vkCmdDraw is using vertex buffers that are not DEVICE_LOCAL"
-              << std::endl;
+    LOG_MESSAGE
+        << "vkCmdDraw is using vertex buffers that are not DEVICE_LOCAL";
   }
 }
 
@@ -209,9 +197,8 @@ void WitchDoctor::PostCallCmdDrawIndirect(VkCommandBuffer commandBuffer,
                                           VkBuffer buffer, VkDeviceSize offset,
                                           uint32_t drawCount, uint32_t stride) {
   if (!m_vertex_buffers_are_device_local) {
-    std::cout
-        << "vkCmdDrawIndirect is using vertex buffers that are not DEVICE_LOCAL"
-        << std::endl;
+    LOG_MESSAGE << "vkCmdDrawIndirect is using vertex buffers that are not "
+                   "DEVICE_LOCAL";
   }
 }
 void WitchDoctor::PostCallCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer,
@@ -220,15 +207,13 @@ void WitchDoctor::PostCallCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer,
                                                  uint32_t drawCount,
                                                  uint32_t stride) {
   if (!m_index_buffer_is_device_local) {
-    std::cout << "vkCmdDrawIndexedIndirect is using index buffer that is not "
-                 "DEVICE_LOCAL"
-              << std::endl;
+    LOG_MESSAGE << "vkCmdDrawIndexedIndirect is using index buffer that is not "
+                   "DEVICE_LOCAL";
   }
 
   if (!m_vertex_buffers_are_device_local) {
-    std::cout << "vkCmdDrawIndexedIndirect is using vertex buffers that are "
-                 "not DEVICE_LOCAL"
-              << std::endl;
+    LOG_MESSAGE << "vkCmdDrawIndexedIndirect is using vertex buffers that are "
+                   "not DEVICE_LOCAL";
   }
 }
 

--- a/src/apiLogic.cpp
+++ b/src/apiLogic.cpp
@@ -52,6 +52,28 @@ VkResult WitchDoctor::PostCallCreateInstance(
   return VK_SUCCESS;
 }
 
+VkResult WitchDoctor::PostCallCreateDebugUtilsMessengerEXT(
+    const VkResult inResult, VkInstance instance,
+    VkDebugUtilsMessengerCreateInfoEXT const* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator,
+    VkDebugUtilsMessengerEXT* pMessenger) {
+  if (VK_SUCCESS != inResult) {
+    return inResult;
+  }
+
+  std::lock_guard<std::mutex> lock(m_debug_utils_messenger_mutex);
+  m_debug_utils_messengers.emplace(*pMessenger, *pCreateInfo);
+
+  return VK_SUCCESS;
+}
+
+void WitchDoctor::PostCallDestroyDebugUtilsMessengerEXT(
+    VkInstance instance, VkDebugUtilsMessengerEXT messenger,
+    const VkAllocationCallbacks* pAllocator) {
+  std::lock_guard<std::mutex> lock(m_debug_utils_messenger_mutex);
+  m_debug_utils_messengers.erase(messenger);
+}
+
 VkResult WitchDoctor::PostCallCreateDevice(
     VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
     const VkAllocationCallbacks* pAllocator, VkDevice* pDevice) {
@@ -149,7 +171,8 @@ void WitchDoctor::PostCallCmdDraw(VkCommandBuffer commandBuffer,
                                   uint32_t firstVertex,
                                   uint32_t firstInstance) {
   if (!m_vertex_buffers_are_device_local) {
-    std::cout << "vkCmdDraw is using vertex buffers that are not DEVICE_LOCAL" << std::endl;
+    std::cout << "vkCmdDraw is using vertex buffers that are not DEVICE_LOCAL"
+              << std::endl;
   }
 }
 
@@ -157,8 +180,9 @@ void WitchDoctor::PostCallCmdDrawIndexed(
     VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
     uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance) {
   if (!m_index_buffer_is_device_local) {
-    std::cout << "vkCmdDrawIndexed is using index buffer that is not DEVICE_LOCAL"
-              << std::endl;
+    std::cout
+        << "vkCmdDrawIndexed is using index buffer that is not DEVICE_LOCAL"
+        << std::endl;
   }
 
   if (!m_vertex_buffers_are_device_local) {
@@ -171,8 +195,9 @@ void WitchDoctor::PostCallCmdDrawIndirect(VkCommandBuffer commandBuffer,
                                           VkBuffer buffer, VkDeviceSize offset,
                                           uint32_t drawCount, uint32_t stride) {
   if (!m_vertex_buffers_are_device_local) {
-    std::cout << "vkCmdDrawIndirect is using vertex buffers that are not DEVICE_LOCAL"
-              << std::endl;
+    std::cout
+        << "vkCmdDrawIndirect is using vertex buffers that are not DEVICE_LOCAL"
+        << std::endl;
   }
 }
 void WitchDoctor::PostCallCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer,
@@ -181,13 +206,14 @@ void WitchDoctor::PostCallCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer,
                                                  uint32_t drawCount,
                                                  uint32_t stride) {
   if (!m_index_buffer_is_device_local) {
-    std::cout
-        << "vkCmdDrawIndexedIndirect is using index buffer that is not DEVICE_LOCAL"
-        << std::endl;
+    std::cout << "vkCmdDrawIndexedIndirect is using index buffer that is not "
+                 "DEVICE_LOCAL"
+              << std::endl;
   }
 
   if (!m_vertex_buffers_are_device_local) {
-    std::cout << "vkCmdDrawIndexedIndirect is using vertex buffers that are not DEVICE_LOCAL"
+    std::cout << "vkCmdDrawIndexedIndirect is using vertex buffers that are "
+                 "not DEVICE_LOCAL"
               << std::endl;
   }
 }

--- a/src/apiLogic.cpp
+++ b/src/apiLogic.cpp
@@ -18,6 +18,7 @@
 #include "layerCore.h"
 
 #include <iostream>
+#include <sstream>
 
 namespace GWD {
 
@@ -171,8 +172,12 @@ void WitchDoctor::PostCallCmdDraw(VkCommandBuffer commandBuffer,
                                   uint32_t firstVertex,
                                   uint32_t firstInstance) {
   if (!m_vertex_buffers_are_device_local) {
-    std::cout << "vkCmdDraw is using vertex buffers that are not DEVICE_LOCAL"
-              << std::endl;
+    //std::cout << "vkCmdDraw is using vertex buffers that are not DEVICE_LOCAL"
+    //          << std::endl;
+
+    std::ostringstream warn_log;
+    warn_log << "vkCmdDraw is using vertex buffers that are not DEVICE_LOCAL";
+    PerformanceWarningMessage(warn_log.str());
   }
 }
 
@@ -180,9 +185,13 @@ void WitchDoctor::PostCallCmdDrawIndexed(
     VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
     uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance) {
   if (!m_index_buffer_is_device_local) {
-    std::cout
-        << "vkCmdDrawIndexed is using index buffer that is not DEVICE_LOCAL"
-        << std::endl;
+    //std::cout
+    //    << "vkCmdDrawIndexed is using index buffer that is not DEVICE_LOCAL"
+    //    << std::endl;
+    std::ostringstream warn_log;
+    warn_log
+        << "vkCmdDrawIndexed is using index buffer that is not DEVICE_LOCAL";
+    PerformanceWarningMessage(warn_log.str());
   }
 
   if (!m_vertex_buffers_are_device_local) {

--- a/src/layerCore.cpp
+++ b/src/layerCore.cpp
@@ -52,16 +52,16 @@ static const uint32_t s_numDeviceExtensions = 0;
 
 // Dispatch tables required for routing instance and device calls onto the next
 // layer in the dispatch chain among our handling of functions we intercept.
-static std::unordered_map<VkInstance, VkLayerInstanceDispatchTable>
+static ska::flat_hash_map<VkInstance, VkLayerInstanceDispatchTable>
     s_instance_dt;
-static std::unordered_map<VkDevice, VkLayerDispatchTable> s_device_dt;
+static ska::flat_hash_map<VkDevice, VkLayerDispatchTable> s_device_dt;
 
 // For finding a dispatch table in EnumeratePhysicalDeviceExtensionProperties
-static std::unordered_map<VkPhysicalDevice, VkInstance> s_device_instance_map;
+static ska::flat_hash_map<VkPhysicalDevice, VkInstance> s_device_instance_map;
 
 // helper maps to find parent device until we try dispatch_keys
-static std::unordered_map<VkCommandBuffer, VkDevice> s_cmdbuf_device_map;
-static std::unordered_map<VkQueue, VkDevice> s_queue_device_map;
+static ska::flat_hash_map<VkCommandBuffer, VkDevice> s_cmdbuf_device_map;
+static ska::flat_hash_map<VkQueue, VkDevice> s_queue_device_map;
 
 // Must protect access to state (maps above) by mutex since the Vulkan
 // application may be calling these functions from different threads.

--- a/src/layerCore.cpp
+++ b/src/layerCore.cpp
@@ -43,11 +43,7 @@ static constexpr const uint32_t kLayerImplVersion = 1;
 static constexpr const uint32_t kLayerSpecVersion = VK_API_VERSION_1_1;
 
 // TODO: Add support for VK_EXT_debug_utils (BLEH)
-// static const VkExtensionProperties s_deviceExtensions[1] = { {
-// VK_EXT_DEBUG_MARKER_EXTENSION_NAME, VK_EXT_DEBUG_MARKER_SPEC_VERSION } };
-// static const uint32_t s_numDeviceExtensions =
-// uint32_t(sizeof(s_deviceExtensions) / sizeof(VkExtensionProperties));
-static const VkExtensionProperties s_deviceExtensions[1] = {};
+//static const VkExtensionProperties s_deviceExtensions[] = {};
 static const uint32_t s_numDeviceExtensions = 0;
 
 // Dispatch tables required for routing instance and device calls onto the next
@@ -419,8 +415,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GwdEnumerateDeviceExtensionProperties(
       }
 
       if (numExtensionsToCopy > 0) {
-        memcpy(pProperties, s_deviceExtensions,
-               numExtensionsToCopy * sizeof(VkExtensionProperties));
+        //memcpy(pProperties, s_deviceExtensions,
+        //       numExtensionsToCopy * sizeof(VkExtensionProperties));
       }
       *pPropertyCount = numExtensionsToCopy;
 
@@ -466,21 +462,21 @@ VKAPI_ATTR VkResult VKAPI_CALL GwdEnumerateDeviceExtensionProperties(
 
   // let's scan the list of extensions from down the chain, and add our unique
   // extensions
-  for (uint32_t extIdx = 0; extIdx < s_numDeviceExtensions; extIdx++) {
-    auto curDeviceExt = s_deviceExtensions[extIdx];
-    bool uniqueExtension = true;
+  //for (uint32_t extIdx = 0; extIdx < s_numDeviceExtensions; extIdx++) {
+  //  auto curDeviceExt = s_deviceExtensions[extIdx];
+  //  bool uniqueExtension = true;
 
-    for (auto extProps : extensions) {
-      if (0 == strcmp(extProps.extensionName, curDeviceExt.extensionName)) {
-        uniqueExtension = false;
-        break;
-      }
-    }
+  //  for (auto extProps : extensions) {
+  //    if (0 == strcmp(extProps.extensionName, curDeviceExt.extensionName)) {
+  //      uniqueExtension = false;
+  //      break;
+  //    }
+  //  }
 
-    if (uniqueExtension) {
-      extensions.push_back(curDeviceExt);
-    }
-  }
+  //  if (uniqueExtension) {
+  //    extensions.push_back(curDeviceExt);
+  //  }
+  //}
 
   if (nullptr == pProperties) {
     // just a count


### PR DESCRIPTION
If the application uses VkDebugUtilsMessengerEXT to process messages from Vulkan, we can hook in ourselves.